### PR TITLE
Add UI table for stored positions

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ from PySide6 import QtWidgets, QtUiTools, QtCore
 from pymodbus.client.tcp import ModbusTcpClient
 
 REG_ACTPOS = 18  # two registers → one float
+REG_POS_BASE = 100  # start address for stored positions
+NUM_POS = 10
 
 def load_ui(ui_path: str) -> QtWidgets.QWidget:
     loader = QtUiTools.QUiLoader()
@@ -32,6 +34,46 @@ def main() -> int:
 
     label = QtWidgets.QLabel("Position: --")
     window.statusbar.addPermanentWidget(label)
+
+    table: QtWidgets.QTableWidget = window.findChild(QtWidgets.QTableWidget, "positionTable")
+    table.setColumnCount(2)
+    table.setHorizontalHeaderLabels(["Index", "Value"])
+    table.setRowCount(NUM_POS)
+    for i in range(NUM_POS):
+        item = QtWidgets.QTableWidgetItem(str(i))
+        item.setFlags(QtCore.Qt.ItemIsEnabled)
+        table.setItem(i, 0, item)
+        table.setItem(i, 1, QtWidgets.QTableWidgetItem("0.0"))
+
+    def refresh_positions():
+        rr = client.read_holding_registers(REG_POS_BASE, count=NUM_POS * 2, slave=1)
+        if rr.isError():
+            return
+        for i in range(NUM_POS):
+            raw = struct.pack(">HH", rr.registers[2 * i], rr.registers[2 * i + 1])
+            pos = struct.unpack(">f", raw)[0]
+            table.item(i, 1).setText(f"{pos:.3f}")
+
+    def write_positions():
+        values = []
+        for i in range(NUM_POS):
+            try:
+                pos = float(table.item(i, 1).text())
+            except (TypeError, ValueError):
+                pos = 0.0
+            raw = struct.pack(">f", pos)
+            hi, lo = struct.unpack(">HH", raw)
+            values.extend([hi, lo])
+        client.write_registers(REG_POS_BASE, values, slave=1)
+
+    refresh_btn = window.findChild(QtWidgets.QPushButton, "refreshButton")
+    if refresh_btn:
+        refresh_btn.clicked.connect(refresh_positions)
+    write_btn = window.findChild(QtWidgets.QPushButton, "writeButton")
+    if write_btn:
+        write_btn.clicked.connect(write_positions)
+
+    refresh_positions()
 
     def poll():
         rr = client.read_holding_registers(REG_ACTPOS, count=2, slave=1)

--- a/smcd14_emulator.py
+++ b/smcd14_emulator.py
@@ -34,6 +34,8 @@ REG_BACKLASH      = 72  # 2 registers (float)
 REG_GAIN          = 74  # 2 registers (float)
 REG_OFFSET        = 76  # 2 registers (float)
 REG_MEMORY_CTRL   = 499
+REG_POS_BASE      = 100  # start address for stored positions
+NUM_POS           = 10
 
 # Default values for those registers
 DEFAULT_REG_VALUES = {
@@ -61,6 +63,10 @@ DEFAULT_REG_VALUES = {
     REG_OFFSET + 1:    0,
     REG_MEMORY_CTRL:   0,
 }
+
+for i in range(NUM_POS):
+    DEFAULT_REG_VALUES[REG_POS_BASE + 2 * i] = 0
+    DEFAULT_REG_VALUES[REG_POS_BASE + 2 * i + 1] = 0
 
 
 def build_context() -> ModbusServerContext:

--- a/ui/main_window.ui
+++ b/ui/main_window.ui
@@ -14,17 +14,40 @@
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QPushButton" name="pushButton">
+   <widget class="QTableWidget" name="positionTable">
     <property name="geometry">
      <rect>
-      <x>470</x>
-      <y>390</y>
-      <width>171</width>
-      <height>91</height>
+      <x>30</x>
+      <y>20</y>
+      <width>256</width>
+      <height>331</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="refreshButton">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>20</y>
+      <width>121</width>
+      <height>41</height>
      </rect>
     </property>
     <property name="text">
-     <string>press me!</string>
+     <string>Refresh</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="writeButton">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>80</y>
+      <width>121</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Write</string>
     </property>
    </widget>
   </widget>


### PR DESCRIPTION
## Summary
- add QTableWidget for position list
- read/write stored positions in app
- store additional registers in emulator for saved positions

## Testing
- `python -m py_compile app.py smcd14_emulator.py`
- `python app.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68504f7f7e408329aa82b7337900b4c6