### PR TITLE
Add position table to GUI

### DIFF
--- a/smcd14_emulator.py
+++ b/smcd14_emulator.py
@@ -34,6 +34,8 @@ REG_BACKLASH      = 72  # 2 registers (float)
 REG_GAIN          = 74  # 2 registers (float)
 REG_OFFSET        = 76  # 2 registers (float)
 REG_MEMORY_CTRL   = 499
+REG_POS_BASE      = 200  # start address for saved positions
+NUM_POSITIONS     = 5
 
 # Default values for those registers
 DEFAULT_REG_VALUES = {
@@ -61,6 +63,11 @@ DEFAULT_REG_VALUES = {
     REG_OFFSET + 1:    0,
     REG_MEMORY_CTRL:   0,
 }
+
+# initialize memory positions
+for i in range(NUM_POSITIONS):
+    DEFAULT_REG_VALUES[REG_POS_BASE + 2 * i] = 0
+    DEFAULT_REG_VALUES[REG_POS_BASE + 2 * i + 1] = 0
 
 
 def build_context() -> ModbusServerContext:

--- a/ui/main_window.ui
+++ b/ui/main_window.ui
@@ -13,21 +13,18 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="QWidget" name="centralwidget">
-   <widget class="QPushButton" name="pushButton">
-    <property name="geometry">
-     <rect>
-      <x>470</x>
-      <y>390</y>
-      <width>171</width>
-      <height>91</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>press me!</string>
-    </property>
+   <widget class="QWidget" name="centralwidget">
+    <widget class="QTableWidget" name="positionTable">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>400</width>
+       <height>300</height>
+      </rect>
+     </property>
+    </widget>
    </widget>
-  </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>


### PR DESCRIPTION
## Summary
- create a table in the UI for saved positions
- read and write position values through Modbus
- support saved position registers in the emulator

## Testing
- `python -m py_compile app.py smcd14_emulator.py`
- `pip install PySide6 pymodbus`
- `python app.py` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68504f7f7e408329aa82b7337900b4c6