### PR TITLE
Add backlash compensation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The GUI communicates with up to three SMCD14 stepper controllers.  By default it
 connects to ``192.168.0.100:502`` using slave IDs ``1``, ``2`` and ``3``.  These
 parameters can be overridden via the command line or the environment variables
 ``SMCD14_HOST``, ``SMCD14_PORT`` and ``SMCD14_SLAVE_IDS`` (comma separated).
+Backlash compensation can be specified with ``--backlash`` or the environment
+variable ``SMCD14_BACKLASH``.
 
 ## Setup
 

--- a/app.py
+++ b/app.py
@@ -45,6 +45,12 @@ def parse_args() -> argparse.Namespace:
         default=int(os.environ.get("SMCD14_TIMEOUT", "10")),
         help="Modbus TCP timeout in seconds",
     )
+    parser.add_argument(
+        "--backlash",
+        type=float,
+        default=float(os.environ.get("SMCD14_BACKLASH", "0")),
+        help="Backlash compensation in mm",
+    )
     return parser.parse_args()
 
 
@@ -131,6 +137,7 @@ def main() -> int:
         port      = args.port,
         timeout   = args.timeout,
         slave_ids = slave_ids,
+        backlash  = args.backlash,
     )
 
     # check connection immediately


### PR DESCRIPTION
## Summary
- allow specifying backlash for SMCD14 axes
- expose `--backlash` CLI option and `SMCD14_BACKLASH` env var
- set backlash when connecting controllers
- document the new feature

## Testing
- `python -m py_compile app.py controllers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685c7baf60e48329a25f1d45a33babd6