### PR TITLE
Add homing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ parameters can be overridden via the command line or the environment variables
 ## Movement Control
 
 Enter the target coordinates in the **X**, **Y**, and **Z** fields and specify the desired **Velocity**. Click **Start Move** to begin, or press **Stop** to halt the motion.
+
+Use the **Home** button to run the homing sequence on all axes. Homing relies on the controller's configured homing type and establishes the reference zero position required for absolute moves.

--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.spin_v    = self.ui.findChild(QtWidgets.QDoubleSpinBox, "spinVelocity")
         self.move_btn  = self.ui.findChild(QtWidgets.QPushButton,     "moveButton")
         self.stop_btn  = self.ui.findChild(QtWidgets.QPushButton,     "stopButton")
+        self.home_btn  = self.ui.findChild(QtWidgets.QPushButton,     "homeButton")
 
         # configure ranges
         for spin in (self.spin_x, self.spin_y, self.spin_z, self.spin_v):
@@ -91,6 +92,8 @@ class MainWindow(QtWidgets.QMainWindow):
         # connect signals
         self.move_btn.clicked.connect(self.start_move)
         self.stop_btn.clicked.connect(self.stop_move)
+        if self.home_btn:
+            self.home_btn.clicked.connect(self.start_home)
 
         # polling timer
         self._timer = QtCore.QTimer(interval=1000, timeout=self.update_position)
@@ -110,6 +113,12 @@ class MainWindow(QtWidgets.QMainWindow):
             self.manipulator.emergency_stop()
         except Exception as exc:
             QtWidgets.QMessageBox.critical(self, "Stop failed", str(exc))
+
+    def start_home(self) -> None:
+        try:
+            self.manipulator.home()
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "Home failed", str(exc))
 
     def update_position(self) -> None:
         try:

--- a/ui/main_window.ui
+++ b/ui/main_window.ui
@@ -62,17 +62,24 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QPushButton" name="moveButton">
-         <property name="text">
-          <string>Move</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="stopButton">
-         <property name="text">
-          <string>Stop</string>
-         </property>
+       <widget class="QPushButton" name="moveButton">
+        <property name="text">
+         <string>Move</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="homeButton">
+        <property name="text">
+         <string>Home</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="stopButton">
+        <property name="text">
+         <string>Stop</string>
+        </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
## Summary
- add homing registers and helpers in controller
- expose `home()` method on `XYZManipulator`
- hook up `Home` button in GUI and implement `start_home`
- add `Home` button widget in UI file
- document the homing feature in README

## Testing
- `python -m py_compile app.py controllers/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c79306ab88329ab8c01d75e0cf47c