### PR TITLE
Add nozzle radius input and µm plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Use the **Home** button to run the homing sequence on all axes. Homing relies on
 
 ### Position Plot
 
-The GUI displays a live **X/Y** plot of the manipulator's position relative to the origin. The graph supports mouse zooming and panning so you can inspect small movements. Each update adds the latest position to the trace while highlighting the current location with a marker.
+The GUI displays a live **X/Y** plot of the manipulator's position relative to the origin. The graph now shows axes in micrometers with an initial 100×100&nbsp;µm view. Each update adds the latest position to the trace while highlighting the current location with a configurable marker whose radius corresponds to the nozzle size. Mouse zooming and panning work both via the dedicated buttons and the scroll wheel or trackpad.

--- a/ui/main_window.ui
+++ b/ui/main_window.ui
@@ -57,6 +57,29 @@
        <item row="3" column="1">
         <widget class="QDoubleSpinBox" name="spinVelocity"/>
        </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_nozzle">
+         <property name="text">
+          <string>Nozzle radius (&micro;m)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QDoubleSpinBox" name="spinNozzle">
+         <property name="decimals">
+          <number>1</number>
+         </property>
+         <property name="minimum">
+          <double>1.0</double>
+         </property>
+         <property name="maximum">
+          <double>1000.0</double>
+         </property>
+         <property name="value">
+          <double>5.0</double>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>


### PR DESCRIPTION
## Summary
- plot manipulator position in micrometers
- show current location as red dot with configurable size
- add nozzle radius control in the UI
- preserve zoom/pan when using scroll wheel

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py --help`

------
https://chatgpt.com/codex/tasks/task_e_685cc0be468883298ac8a856a63cdca3